### PR TITLE
fix: remove extname from reName(移除在重命名文件时增加后缀)

### DIFF
--- a/src/utils/reName.ts
+++ b/src/utils/reName.ts
@@ -3,12 +3,11 @@ import * as path from 'path'
 
 export function reName(nameType: string, url: string): string {
   const fileName = path.basename(url)
-  const extname = path.extname(url)
   switch (nameType) {
     case NameType.timestamp:
-      return `${Date.now()}${extname}`
+      return `${Date.now()}$`
     case NameType.none:
     default:
-      return `${fileName}${extname}`
+      return `${fileName}$`
   }
 }


### PR DESCRIPTION
fileName 重命名不需要加上后缀，后续 picgo 会补充添加，这样会导致图片压缩后拥有两个后缀。